### PR TITLE
fix: update vue dependency to support version 2.7.0 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,11 @@
     "body-scroll-lock": "^3.1.5",
     "core-js": "^3.6.5",
     "dayjs": "^1.10.4",
-    "vue": "^2.6.11",
     "vue-click-outside": "^1.1.0",
     "vue-cropperjs": "4.2.0"
+  },
+  "peerDependencies": {
+    "vue": "^2.6.11 || ^2.7.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.1.14",
@@ -84,6 +86,7 @@
     "vue-loader": "^15.9.6",
     "vue-style-loader": "^4.1.2",
     "vue-svg-loader": "^0.16.0",
+    "vue": "^2.6.11",
     "vue-template-compiler": "^2.6.11"
   }
 }


### PR DESCRIPTION
## Summary

This PR updates the Vue.js dependency configuration to properly support both Vue 2.6.x and 2.7.x versions.

## Changes

- **Moved Vue dependency**: Moved vue from dependencies to devDependencies since this is a component library
- **Added peerDependencies**: Added vue as a peer dependency with version range ^2.6.11 || ^2.7.0 to support both Vue 2.6.x and 2.7.x
- **Maintained dev dependency**: Kept Vue 2.6.11 in devDependencies for development and testing

## Why this change?

Component libraries should typically declare framework dependencies as peer dependencies rather than direct dependencies. This allows consumers to use their preferred version of Vue (within the supported range) without version conflicts.

## Testing

- Ensures compatibility with Vue 2.6.11 and newer 2.7.x versions
- Prevents npm/yarn from installing duplicate Vue instances
- Allows consuming applications to control their Vue version